### PR TITLE
Add support for the Deimos Adventures expansion

### DIFF
--- a/global.lua
+++ b/global.lua
@@ -188,6 +188,20 @@ function onLoad()
         {position={9.86,1,-7.42}, rotation={0,120,0}},
         {position={11.36,1,-4.83}, rotation={0,120,0}},
         {position={12.86,1,-2.23}, rotation={0,120,0}},
+        
+        {position={8.01,1,-4.63}, rotation={0,120,0}},
+        {position={8.56,1,-6.67}, rotation={0,120,0}},
+        {position={10.06,1,-4.08}, rotation={0,120,0}},
+        {position={9.11,1,-8.72}, rotation={0,120,0}},
+        {position={10.61,1,-6.12}, rotation={0,120,0}},
+        {position={12.11,1,-3.53}, rotation={0,120,0}},
+
+        {position={5.96,1,-5.18}, rotation={0,120,0}},
+        {position={7.46,1,-2.58}, rotation={0,120,0}},
+        {position={6.51,1,-7.22}, rotation={0,120,0}},
+        {position={9.51,1,-2.03}, rotation={0,120,0}},
+        {position={7.06,1,-9.27}, rotation={0,120,0}},
+        {position={11.56,1,-1.48}, rotation={0,120,0}},
     }
 
     modifierLocations = {

--- a/global.xml
+++ b/global.xml
@@ -17,7 +17,7 @@
 
 <Panel id="Game" height="400" width="400" color="#000000F0" allowDragging="true" returnToOriginalPositionWhenReleased="false" showAnimation="FadeIn" hideAnimation="FadeOut" animationDuration="1" active="false">
     <Text id="taskTitle" position="0 150 0" fontStyle="Bold" fontSize="36" text="Task Count = 0" color="#828282"></Text>
-    <Slider id="taskSlider" position="0 100 0" width="350" minValue="0" maxValue="10" value="0" wholeNumbers="true" onValueChanged="updateSliderValue"/>
+    <Slider id="taskSlider" position="0 100 0" width="350" minValue="0" maxValue="22" value="0" wholeNumbers="true" onValueChanged="updateSliderValue"/>
     <HorizontalLayout offsetXY="0 50" height="50" width="350" spacing="10">
       <ToggleButton id="mod1" icon="mod1"></ToggleButton>
       <ToggleButton id="mod2" icon="mod2"></ToggleButton>


### PR DESCRIPTION
The publisher has released a print&play expansion called the Deimos Adventures: https://www.thamesandkosmos.com/index.php/educators/scienceathome/category/the-crew-the-deimos-adventures
Most of the new missions can be played using the mod as-is, but mission A3 has 22 tasks.
This change adds 12 new task locations and increases the maximum value of the task slider to allow up to 22.